### PR TITLE
Override SSL context to allow DEFAULT@SECLEVEL=1 ciphers

### DIFF
--- a/src/baseclient.cpp
+++ b/src/baseclient.cpp
@@ -90,6 +90,11 @@ std::string BaseClient::get_password() const
 
 void BaseClient::ssl_prepare(boost::asio::ssl::context &ssl_context) const
 {
+   /* Default to SECLEVEL=1 to allow connecting to legacy
+   * networks since Debian OpenSSL is set to minimum TLSv1.2 and SECLEVEL=2. */
+   char const *ciphers = "DEFAULT@SECLEVEL=1";
+   SSL_CTX_set_cipher_list(ssl_context.native_handle(), ciphers);
+
    ssl_context.set_password_callback(boost::bind(&BaseClient::get_password,this));
    ssl_context.set_verify_mode(boost::asio::ssl::context::verify_peer|boost::asio::ssl::context::verify_fail_if_no_peer_cert);
    ssl_context.load_verify_file(my_certs_name);

--- a/src/localclient.cpp
+++ b/src/localclient.cpp
@@ -382,6 +382,10 @@ void LocalHost::go_out(boost::asio::io_service &io_service)
       boost::asio::deadline_timer deadline(io_service);
       mylib::protect_pointer<boost::asio::deadline_timer> p_deadline( this->m_pdeadline, deadline, this->m_mutex );
       boost::asio::ssl::context ssl_context(boost::asio::ssl::context::tlsv12);
+      /* Default to SECLEVEL=1 to allow connecting to legacy
+      * networks since Debian OpenSSL is set to minimum TLSv1.2 and SECLEVEL=2. */
+      char const *ciphers = "DEFAULT@SECLEVEL=1";
+      SSL_CTX_set_cipher_list(ssl_context.native_handle(), ciphers);
       ssl_context.set_password_callback(boost::bind(&LocalHost::get_password,this));
       ssl_context.set_verify_mode(boost::asio::ssl::context::verify_peer|boost::asio::ssl::context::verify_fail_if_no_peer_cert);
       ssl_context.load_verify_file(my_certs_name);

--- a/src/providerclient.cpp
+++ b/src/providerclient.cpp
@@ -182,6 +182,10 @@ void ProviderClient::threadproc_writer()
 
          boost::asio::io_service io_service;
          boost::asio::ssl::context ssl_context(boost::asio::ssl::context::tlsv12);
+         /* Default to SECLEVEL=1 to allow connecting to legacy
+         * networks since Debian OpenSSL is set to minimum TLSv1.2 and SECLEVEL=2. */
+         char const *ciphers = "DEFAULT@SECLEVEL=1";
+         SSL_CTX_set_cipher_list(ssl_context.native_handle(), ciphers);
          ssl_context.set_password_callback(boost::bind(&ProviderClient::get_password,this));
          ssl_context.set_verify_mode(boost::asio::ssl::context::verify_peer|boost::asio::ssl::context::verify_fail_if_no_peer_cert);
          ssl_context.load_verify_file(my_certs_name);
@@ -325,6 +329,10 @@ void ProviderClient::threadproc_reader()
          else
          {
             boost::asio::ssl::context ssl_context(boost::asio::ssl::context::tlsv12);
+            /* Default to SECLEVEL=1 to allow connecting to legacy
+            * networks since Debian OpenSSL is set to minimum TLSv1.2 and SECLEVEL=2. */
+            char const *ciphers = "DEFAULT@SECLEVEL=1";
+            SSL_CTX_set_cipher_list(ssl_context.native_handle(), ciphers);
             ssl_context.set_password_callback(boost::bind(&ProviderClient::get_password,this));
             ssl_context.set_verify_mode(boost::asio::ssl::context::verify_peer|boost::asio::ssl::context::verify_fail_if_no_peer_cert);
             ssl_context.load_verify_file(my_certs_name);

--- a/src/proxy_global.cpp
+++ b/src/proxy_global.cpp
@@ -730,6 +730,10 @@ bool proxy_global::load_configuration()
          {
             boost::system::error_code ec1,ec2;
             boost::asio::ssl::context ctx(boost::asio::ssl::context_base::tlsv12);
+            /* Default to SECLEVEL=1 to allow connecting to legacy
+            * networks since Debian OpenSSL is set to minimum TLSv1.2 and SECLEVEL=2. */
+            char const *ciphers = "DEFAULT@SECLEVEL=1";
+            SSL_CTX_set_cipher_list(ctx.native_handle(), ciphers);
             ctx.use_private_key_file(my_private_key_name,boost::asio::ssl::context_base::file_format::pem,ec1);
             ctx.use_certificate_file(my_public_cert_name,boost::asio::ssl::context_base::file_format::pem,ec2);
             load_private = !ec1 && !ec2;

--- a/src/remoteclient.cpp
+++ b/src/remoteclient.cpp
@@ -479,6 +479,11 @@ RemoteProxyHost::RemoteProxyHost( unsigned short _local_port, const std::vector<
    SSL_CTX_set_verify_depth( this->m_context.native_handle(), 4 ); 
 #endif
 
+   /* Default to SECLEVEL=1 to allow connecting to legacy
+   * networks since Debian OpenSSL is set to minimum TLSv1.2 and SECLEVEL=2. */
+   char const *ciphers = "DEFAULT@SECLEVEL=1";
+   SSL_CTX_set_cipher_list(this->m_context.native_handle(), ciphers);
+
    this->m_context.load_verify_file( my_certs_name );
    this->m_context.use_certificate_chain_file(my_public_cert_name);
    this->m_context.use_private_key_file(my_private_key_name, boost::asio::ssl::context::pem);


### PR DESCRIPTION
Hello,

If you're running a recent enough distribution (Debian Buster for example), /etc/ssl/openssl.cnf contains "CipherString = DEFAULT@SECLEVEL=2".
When running uniproxy with this configuration, it fails with "ee key too small".
This patch ask for a lower level of cipher encryption by calling SSL_CTX_set_cipher_list to set SECLEVEL=1.
It's inspired of a patch that has been created for wpa_supplicant.

Regards, Adam.